### PR TITLE
Initialise temp_change_over_time

### DIFF
--- a/Keithley_2700Sup/drift_utils.cpp
+++ b/Keithley_2700Sup/drift_utils.cpp
@@ -4,21 +4,20 @@
 
 #include <epicsMath.h> /* defines isnan() if it is not already present */
 
-#define SMOOTHING_FACTOR 50
+#define SMOOTHING_FACTOR 50.0
 
-double previous_proportion = 1.0 - (1.0/SMOOTHING_FACTOR);
+static double previous_proportion = 1.0 - (1.0 / SMOOTHING_FACTOR);
 
 double drift_function_impl(double temp_delta, double time_delta, double previous_drift, 
                            double prev_temp)
 {
-    double temp_change_over_time, new_drift = 0;
+    double temp_change_over_time = 0.0, new_drift = 0.0;
     previous_drift = previous_drift * previous_proportion;
 
     // If there is previous temperature data
-    if (prev_temp > 0) {
-        temp_change_over_time = ((temp_delta/time_delta)*60); // seconds in minute
+    if (prev_temp > 0.0) {
+        temp_change_over_time = ((temp_delta / time_delta) * 60.0) / SMOOTHING_FACTOR; // seconds in minute
     }
-    temp_change_over_time = temp_change_over_time/SMOOTHING_FACTOR;
 
     // If temp_change_over_time IS a number AND the previous drift is NOT a number
     // (i.e. this is the first reading) set the drift to equal only the new 


### PR DESCRIPTION
temp_change_over_time  was being used uninitialised in some cases, in particular the ioc tests. I assumed setting to zero is reasonable, but NaN is another option. Could somebody familiar with the Keithley take a look.