### PR TITLE
Ticket 5513: Updated to the standard epics way of running tests

### DIFF
--- a/Keithley_2700Sup/Makefile
+++ b/Keithley_2700Sup/Makefile
@@ -23,19 +23,17 @@ Keithley2700_LIBS += $(EPICS_BASE_IOC_LIBS)
 
 #=======================================
 # googleTest Runner
-# Does not currently build on build servers
 
 ifeq ($(findstring 10.0,$(VCVERSION)),)
 
 SRC_DIRS += $(TOP)/Keithley_2700Sup/tests
 
-TESTPROD_HOST += runner
-USR_CPPFLAGS += -I$(GTEST)/googletest/include
-runner_LIBS += gtest
-runner_SRCS += run_all_tests.cc drift_tests.cc
-runner_SRCS += drift_utils.cpp
-
+GTESTPROD_HOST += runner
+runner_SRCS += drift_tests.cc drift_utils.cpp
+GTESTS += runner
 endif
 
 #=======================================
 include $(TOP)/configure/RULES
+
+include $(GTEST)/cfg/compat.RULES_BUILD

--- a/Keithley_2700Sup/tests/run_all_tests.cc
+++ b/Keithley_2700Sup/tests/run_all_tests.cc
@@ -1,6 +1,0 @@
-#include "gtest/gtest.h"
-
-int main(int argc, char **argv) {
-    ::testing::InitGoogleTest( &argc, argv );
-    return RUN_ALL_TESTS();
-    }

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,4 @@ DIRS += $(wildcard *[Ss]up)
 DIRS += $(wildcard *[Aa]pp)
 DIRS += $(wildcard ioc[Bb]oot)
 
-TEST_RUNNER = $(TOP)/Keithley_2700Sup/O.$(EPICS_HOST_ARCH)/runner
-
 include $(TOP)/configure/RULES_TOP

--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,3 @@ DIRS += $(wildcard ioc[Bb]oot)
 TEST_RUNNER = $(TOP)/Keithley_2700Sup/O.$(EPICS_HOST_ARCH)/runner
 
 include $(TOP)/configure/RULES_TOP
-
-.PHONY: test
-test:
-ifneq ($(wildcard $(TEST_RUNNER)*),)
-	$(TEST_RUNNER) --gtest_output=xml:$(TOP)/test-reports/TEST-Keithley2700.xml
-endif


### PR DESCRIPTION
See https://github.com/ISISComputingGroup/IBEX/issues/5513

To test:

* Run `make runtests` in this submodule and confirm tests run